### PR TITLE
Feature/reflect markdown

### DIFF
--- a/app/assets/javascripts/memo.js
+++ b/app/assets/javascripts/memo.js
@@ -41,3 +41,12 @@ document.addEventListener('turbolinks:load', () => {
     memoArea.addEventListener('change', registerMemo)
     backButton.addEventListener('click', backDisplay)
 })
+
+function count_up(obj) {
+    var element = document.getElementById('memo-count');
+    element.innerHTML = obj.value.length;
+
+    if (obj.value.length > 30000) {
+        element.style.color = 'red';
+    }
+}

--- a/app/assets/javascripts/memo.js
+++ b/app/assets/javascripts/memo.js
@@ -48,5 +48,6 @@ function count_up(obj) {
 
     if (obj.value.length > 30000) {
         element.style.color = 'red';
-    }
+        alert("30,000文字以内にしてください");
+    } 
 }

--- a/app/assets/stylesheets/_memo.scss
+++ b/app/assets/stylesheets/_memo.scss
@@ -12,7 +12,8 @@
   width: 100%;
 }
 
-.memo-preview-area.d-none {
-  border: 2px;
+.memo-preview-area {
+  border: 1px solid #ced4da;
+  border-radius: 0.25em;
   width: 100%;
 }

--- a/app/assets/stylesheets/_memo.scss
+++ b/app/assets/stylesheets/_memo.scss
@@ -11,3 +11,7 @@
   max-width: 250px;
   width: 100%;
 }
+
+.memo-preview-area {
+  line-height: 1.3;
+}

--- a/app/assets/stylesheets/_memo.scss
+++ b/app/assets/stylesheets/_memo.scss
@@ -12,6 +12,7 @@
   width: 100%;
 }
 
-.memo-preview-area {
-  line-height: 1.3;
+.memo-preview-area.d-none {
+  border: 2px;
+  width: 100%;
 }

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -10,6 +10,7 @@ class MemosController < ApplicationController
   end
 
   def preview
+    @memo = Memo.find_by(user_id: current_user.id)
   end
 
   private

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -19,5 +19,5 @@
 class Memo < ApplicationRecord
   belongs_to :user
   validates :user_id, uniqueness: true
-  validates :content, length: { maximum: 30000 }
+  validates :content, length: { maximum: 30000 } 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
-#  approval_at            :datetime         default(Tue, 16 Jun 2020 16:36:58 JST +09:00)
+#  approval_at            :datetime         default(Sun, 14 Mar 2021 06:51:12 JST +09:00)
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
 #  email                  :string           default(""), not null

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -77,17 +77,17 @@
               マイページ
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-              <%= link_to "メモ", memos_path, class: "dropdown-item" %>
+              <%= link_to "メモ", memos_path, class: "dropdown-item", data: { turbolinks: false } %>
               <%= link_to "進捗管理", my_pages_path, class: "dropdown-item" %>
               <%= link_to "アカウント編集", edit_user_registration_path, class: "dropdown-item" %>
               <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
             </div>
-        <% else %>
-          <li class="nav-item">
-            <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </nav>
-</header>
+          <% else %>
+            <li class="nav-item">
+              <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </nav>
+  </header>

--- a/app/views/memos/_preview.html.erb
+++ b/app/views/memos/_preview.html.erb
@@ -1,0 +1,3 @@
+<div class="markdown" id="markdowend-text">
+  <%= markdown(@memo.content) %>
+</div>

--- a/app/views/memos/preview.js.erb
+++ b/app/views/memos/preview.js.erb
@@ -4,3 +4,5 @@ memoPreviewArea.classList.remove('d-none')
 
 previewButton.classList.add("d-none")
 memoArea.classList.add('d-none')
+
+document.getElementById('memo-preview-area').innerHTML = '<%= j render("/memos/preview", memo: @memo) %>'

--- a/app/views/memos/preview.js.erb
+++ b/app/views/memos/preview.js.erb
@@ -1,3 +1,4 @@
+
 backButton.classList.remove('d-none')
 memoPreviewArea.classList.remove('d-none')
 

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -15,4 +15,5 @@
 </form>
 <div class="text-right"><span id="memo-count">0</span>/30000</div>
 
+
 <%= render 'help_modal' %>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -8,7 +8,7 @@
   <div class="form-group mb-0">
     <%# 非プレビュー時に表示 %>
     <label for="memo-area"></label>
-    <textarea class="form-control memo-area" id="memo-area"><%= @memo.content %></textarea>
+    <textarea class="form-control memo-area" id="memo-area" onkeyup="count_up(this);"><%= @memo.content %></textarea>
     <%# プレビュー時に表示 %>
     <div class="memo-preview-area d-none" id="memo-preview-area"></div>
   </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,16 +127,6 @@ ActiveRecord::Schema.define(version: 2021_04_08_012953) do
     t.integer "text_id"
   end
 
-  create_table "progresses", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "materiable_type"
-    t.bigint "materiable_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["materiable_type", "materiable_id"], name: "index_progresses_on_materiable_type_and_materiable_id"
-    t.index ["user_id"], name: "index_progresses_on_user_id"
-  end
-
   create_table "questions", force: :cascade do |t|
     t.string "title"
     t.text "content"
@@ -181,7 +171,7 @@ ActiveRecord::Schema.define(version: 2021_04_08_012953) do
     t.inet "last_sign_in_ip"
     t.boolean "flag", default: false
     t.string "slack_id", null: false
-    t.datetime "approval_at", default: "2020-06-16 07:36:58"
+    t.datetime "approval_at", default: "2021-03-13 21:51:12"
     t.integer "slack_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -215,7 +205,6 @@ ActiveRecord::Schema.define(version: 2021_04_08_012953) do
   add_foreign_key "complete_challenges", "users"
   add_foreign_key "memos", "users"
   add_foreign_key "movies", "genres"
-  add_foreign_key "progresses", "users"
   add_foreign_key "questions", "genres"
   add_foreign_key "texts", "genres"
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
-#  approval_at            :datetime         default(Tue, 16 Jun 2020 16:36:58 JST +09:00)
+#  approval_at            :datetime         default(Sun, 14 Mar 2021 06:51:12 JST +09:00)
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
 #  email                  :string           default(""), not null


### PR DESCRIPTION
## 実装内容

- 文字数カウント機能
  - 30,000字を超えると赤くなる
  - 30,000字を超えるとアラートを表示
- マークダウンを反映して表示する機能
  - プレビュー表示箇所に入力フォームに近いデザインの枠を表示

## 参考資料

- 文字数カウント機能
  - [【JavaScript】テキストエリア 文字数カウンターの作り方（カウントアップ・ダウン）](https://codeforfun.jp/javascript-text-count-up-and-down/)

- マークダウンを反映して表示する機能
  -  [やんばるエキスパートアプリ](https://www.yanbaru-code.com/texts/297)


## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行
