### PR TITLE
マークダウン反映のプルリクの修正案

### DIFF
--- a/app/assets/javascripts/memo.js
+++ b/app/assets/javascripts/memo.js
@@ -1,53 +1,80 @@
 document.addEventListener('turbolinks:load', () => {
-    const csrfToken = document.querySelector('meta[name="csrf-token"]').content
+  const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
 
-    window.previewButton = document.getElementById('memo-preview-btn')
-    window.backButton = document.getElementById('memo-back-btn')
-    window.memoArea = document.getElementById('memo-area')
-    window.memoPreviewArea = document.getElementById('memo-preview-area')
+  window.previewButton = document.getElementById('memo-preview-btn');
+  window.backButton = document.getElementById('memo-back-btn');
+  window.memoArea = document.getElementById('memo-area');
+  window.memoPreviewArea = document.getElementById('memo-preview-area');
+  const memoCount = document.getElementById('memo-count');
+  let length = 0;
+  const maxLength = 100000;
+  let saveStatus = false;
 
-    const registerMemo = (e) => {
-        e.preventDefault()
-        if (previewButton.classList.contains("disabled")) return
+  // メモの保存処理
+  const registerMemo = async (e) => {
+    e.preventDefault();
 
-        previewButton.classList.add("disabled")
-        previewButton.textContent = "保存中……"
-        const memoParams = {memo: {content: memoArea.value}}
-        fetch(' /memos', {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRF-Token': csrfToken
-            },
-            body: JSON.stringify(memoParams)
-        })
-            .then(() => {
-                previewButton.classList.remove("disabled")
-                previewButton.textContent = "プレビュー"
-            }).catch(() => {
-            previewButton.textContent = "保存に失敗"
-            alert('保存に失敗しました。インターネットの接続状況をご確認下さい。')
-        })
+    // 文字数がオーバーしている場合は，保存しない
+    if (length > maxLength) {
+      previewButton.classList.add('disabled');
+      alert(`保存に失敗しました。${maxLength.toLocaleString()}文字以内にしてください。`);
+      return;
     }
 
-    const backDisplay = () => {
-        backButton.classList.add('d-none')
-        memoPreviewArea.classList.add('d-none')
+    // 保存中の場合は処理を実行しない
+    if (saveStatus) return;
 
-        previewButton.classList.remove("d-none")
-        memoArea.classList.remove('d-none')
+    try {
+      previewButton.classList.add('disabled');
+      saveStatus = true;
+      previewButton.textContent = '保存中……';
+      const memoParams = { memo: { content: memoArea.value } };
+
+      response = await fetch(' /memos', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+        body: JSON.stringify(memoParams),
+      });
+
+      if (!response.ok) {
+        throw new Error(`${response.status} (${response.statusText})`);
+      }
+
+      previewButton.classList.remove('disabled');
+      previewButton.textContent = 'プレビュー';
+    } catch (error) {
+      previewButton.textContent = '保存に失敗';
+      let message;
+      if (error.message === 'Failed to fetch') {
+        message = '送信に失敗しました。インターネットの接続状況をご確認下さい。';
+      } else {
+        message = `保存に失敗しました。${error}`;
+      }
+      alert(message);
+    } finally {
+      saveStatus = false;
     }
+  };
 
-    memoArea.addEventListener('change', registerMemo)
-    backButton.addEventListener('click', backDisplay)
-})
+  const backDisplay = () => {
+    backButton.classList.add('d-none');
+    memoPreviewArea.classList.add('d-none');
 
-function count_up(obj) {
-    var element = document.getElementById('memo-count');
-    element.innerHTML = obj.value.length;
+    previewButton.classList.remove('d-none');
+    memoArea.classList.remove('d-none');
+  };
 
-    if (obj.value.length > 30000) {
-        element.style.color = 'red';
-        alert("30,000文字以内にしてください");
-    } 
-}
+  const countUp = () => {
+    length = memoArea.value.length;
+    memoCount.textContent = length.toLocaleString();
+    memoCount.style.color = length > maxLength ? 'red' : '#495057';
+  };
+
+  countUp();
+  memoArea.addEventListener('change', registerMemo);
+  memoArea.addEventListener('keyup', countUp);
+  backButton.addEventListener('click', backDisplay);
+});

--- a/app/assets/stylesheets/_memo.scss
+++ b/app/assets/stylesheets/_memo.scss
@@ -13,7 +13,9 @@
 }
 
 .memo-preview-area {
+  padding: 1rem;
   border: 1px solid #ced4da;
   border-radius: 0.25em;
   width: 100%;
+  word-break: break-all;
 }

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -19,5 +19,5 @@
 class Memo < ApplicationRecord
   belongs_to :user
   validates :user_id, uniqueness: true
-  validates :content, length: { maximum: 30000 } 
+  validates :content, length: { maximum: 100000 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # Table name: users
 #
 #  id                     :bigint           not null, primary key
-#  approval_at            :datetime         default(Sun, 14 Mar 2021 06:51:12 JST +09:00)
+#  approval_at            :datetime         default(Tue, 16 Jun 2020 16:36:58 JST +09:00)
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
 #  email                  :string           default(""), not null

--- a/app/views/memos/_preview.html.erb
+++ b/app/views/memos/_preview.html.erb
@@ -1,3 +1,1 @@
-<div class="markdown" id="markdowend-text">
-  <%= markdown(@memo.content) %>
-</div>
+<%= markdown(@memo.content) %>

--- a/app/views/memos/show.html.erb
+++ b/app/views/memos/show.html.erb
@@ -3,17 +3,14 @@
   <button class="btn btn-primary btn-lg memo-btn d-none" id="memo-back-btn">戻る</button>
   <button type="button" class="btn btn-primary btn-lg memo-hint-btn" id="memo-hint-btn" data-toggle="modal" data-target="#memoHelpModal">？</button>
 </div>
-
 <form id="memo-form">
   <div class="form-group mb-0">
     <%# 非プレビュー時に表示 %>
     <label for="memo-area"></label>
-    <textarea class="form-control memo-area" id="memo-area" onkeyup="count_up(this);"><%= @memo.content %></textarea>
+    <textarea class="form-control memo-area" id="memo-area"><%= @memo.content %></textarea>
     <%# プレビュー時に表示 %>
-    <div class="memo-preview-area d-none" id="memo-preview-area"></div>
+    <div class="memo-preview-area markdown d-none" id="memo-preview-area"></div>
   </div>
 </form>
-<div class="text-right"><span id="memo-count">0</span>/30000</div>
-
-
+<div class="text-right"><span id="memo-count">0</span> / 100,000</div>
 <%= render 'help_modal' %>


### PR DESCRIPTION
## 実装内容

- プレビュー表示のスタイルを調整
  - paddingを設定
  - はみ出る場合は強制改行
- HTMLのリファクタリング
  - `markdown` のクラスをつける場所を変更
  - イベントはJSに移動
- JSのリファクタリング
- 文字数制限を「3万文字」から「10万文字」に変更
- 文字数制限をオーバーした際はアラームを出し，サーバーにリクエストを出さないように修正
- 文字数制限を一度超えると，文字数を減らしても「赤色」のままになる問題を修正
