### PR TITLE
Feature/design cta

### DIFF
--- a/app/assets/stylesheets/design.scss
+++ b/app/assets/stylesheets/design.scss
@@ -225,7 +225,7 @@
         }
   
       }
-      button{
+      button, a{
         width: 263px;
         height: 55px;
         margin-top: 16px;
@@ -234,7 +234,7 @@
         color: $main-color;
         font-size: 20px;
         font-weight: $strength-font;
-        line-height: 60px;
+        line-height: 55px;
         float: right;
         @include sp{
           height: 36px;
@@ -242,7 +242,7 @@
           margin-bottom: auto;
           margin-top: 10px;
           font-size: 12px;
-          line-height: 28px;
+          line-height: 40px;
         };
         &::after{
           content: "  >";

--- a/app/assets/stylesheets/design.scss
+++ b/app/assets/stylesheets/design.scss
@@ -142,7 +142,7 @@
     h4{
       color: $white-color;
     }
-    button{
+    button, a{
       display: block;
       width: fit-content;
       margin: 0 auto;
@@ -159,7 +159,7 @@
         z-index: 5;
         width: calc(100% -20px) !important;
         max-width: 450px;
-        font-size: 19px;
+        font-size: 17px;
         padding: 20px 20px;
       };
       &:hover{
@@ -171,12 +171,20 @@
         top: 5px;
       }
     }
+    .l-step{
+      background-color: #4CCE4C;
+      box-shadow: 0 5px 0 0 #205b20;
+        &:hover{
+        background-color: #62df62;
+        transition: .3s;
+      }
+    }
     h6{
       font-size: $subtitle-font-size;
       margin-top: 0;
       margin-bottom: 0;
       @include sp{
-        font-size: 18px;
+        font-size: 17px;
       };
     }
   }

--- a/app/assets/stylesheets/design.scss
+++ b/app/assets/stylesheets/design.scss
@@ -1070,6 +1070,9 @@
               height: 50px;
               margin-top: 20px;
               margin-left: 45px;
+            }
+            @include sp{
+              height: 50px;
               margin-right: -30px;
             }
           }
@@ -1081,6 +1084,9 @@
             margin: 0;
             @include pc{
               font-size: 50px;
+            }
+            @include sp{
+              font-size: 42px;
             }
             &::after{
               content: "円(税込）";

--- a/app/assets/stylesheets/php_lp.scss
+++ b/app/assets/stylesheets/php_lp.scss
@@ -203,7 +203,7 @@
           display: none;
         }
       }
-      button{
+      button, a{
         height: 100%;
         font-size: 1.5rem;
         padding: .875rem 2.75rem;
@@ -215,10 +215,19 @@
           transition: .3s;
         }
       }
+      .l-step{
+        background-color: #4CCE4C;
+        box-shadow: 0 5px 0 0 #205b20;
+        color: white;
+          &:hover{
+          background-color: #62df62;
+          transition: .3s;
+        }
+      }
       @include sp{
         height: 3.875rem;
         padding-left: 1rem;
-        button{
+        button, a{
           font-size: .875rem;
           padding: 10px 1rem;
         }

--- a/app/assets/stylesheets/php_lp.scss
+++ b/app/assets/stylesheets/php_lp.scss
@@ -328,7 +328,7 @@
           font-size: 1rem;
         }
       }
-      button{
+      button, a{
         margin: 0 auto;
         padding: .75rem 6rem .9rem 6rem;
         line-height: 1.6rem;
@@ -352,6 +352,24 @@
           max-width: 400px;
           padding: .5rem 0;
           font-size: 1.375rem;
+        }
+      }
+      .l-step{
+        display: block;
+        margin: 0 auto;
+        font-size: 1.5rem;
+        padding-top: 1.5rem;
+        padding-bottom: 1.5rem;
+        background-color: #4CCE4C;
+        box-shadow: 0 5px 0 0 #205b20;
+        color: white;
+        &:hover{
+          background-color: #62df62;
+          transition: .3s;
+        }
+        @include sp{
+          font-size: 1.2rem;
+          font-weight: 600;
         }
       }
     }

--- a/app/helpers/day_helper.rb
+++ b/app/helpers/day_helper.rb
@@ -5,6 +5,6 @@ module DayHelper
 
   def deadline_judge
     # 毎月24日以降にtrue
-    Date.current - Date.current.beginning_of_month >= 23
+    Date.current - Date.current.beginning_of_month >= 28
   end
 end

--- a/app/helpers/day_helper.rb
+++ b/app/helpers/day_helper.rb
@@ -5,6 +5,6 @@ module DayHelper
 
   def deadline_judge
     # 毎月24日以降にtrue
-    Date.current - Date.current.beginning_of_month >= 28
+    Date.current - Date.current.beginning_of_month >= 23
   end
 end

--- a/app/helpers/day_helper.rb
+++ b/app/helpers/day_helper.rb
@@ -1,0 +1,10 @@
+module DayHelper
+  def end_month_info
+    Date.current.end_of_month.strftime("%m月").delete_prefix("0")
+  end
+
+  def deadline_judge
+    # 毎月24日以降にtrue
+    Date.current - Date.current.beginning_of_month >= 23
+  end
+end

--- a/app/views/static_pages/_php_cta.html.erb
+++ b/app/views/static_pages/_php_cta.html.erb
@@ -24,10 +24,15 @@
   </div>
   <!-- cta-container -->
   <div class="cta-btn">
-    <h3>＼ 5月末まで!! 8名限定／</h3>
-    <button class="cta-btn" role="link" type="button"><%= image_tag "https://d5izmuz0mcjzz.cloudfront.net/php/triangle.svg" %><span>無期限の転職サポート付き！</span>
-        PHP講座を申し込む
-    </button>
+    <% if deadline_judge %>
+    <h3>＼ <%= end_month_info %>末まで!! 8名限定／</h3>
+      <button class="cta-btn" role="link" type="button"><%= image_tag "https://d5izmuz0mcjzz.cloudfront.net/php/triangle.svg" %><span>無期限の転職サポート付き！</span>
+          PHP講座を申し込む
+      </button>
+    <% else %>
+      <h3>\次回<%= end_month_info %>24日から募集開始/</h3>
+      <a href="https://line.me/R/ti/p/%40fyp8311b" class="l-step cta-btn">LINEで先行情報を入手する</a>
+    <% end %>
   </div>
   <!-- cta-btn -->
 </section>

--- a/app/views/static_pages/_stripe.html.erb
+++ b/app/views/static_pages/_stripe.html.erb
@@ -1,5 +1,10 @@
-<h6>\5月末まで!!20名限定/</h6>
-<button class="cta-btn" role="link" type="button">
-  webデザイン講座を申し込む
-</button>
-<div id="error-message"></div>
+<% if deadline_judge %>
+  <h6>\<%= end_month_info %>末まで!!20名限定/</h6>
+  <button class="cta-btn" role="link" type="button">
+    webデザイン講座を申し込む
+  </button>
+  <div id="error-message"></div>
+<% else %>
+  <h6>\次回<%= end_month_info %>24日から募集開始/</h6>
+  <a href="https://line.me/R/ti/p/%40fyp8311b" class="l-step cta-btn">LINEで先行情報を入手する</a>
+<% end %>

--- a/app/views/static_pages/design.html.erb
+++ b/app/views/static_pages/design.html.erb
@@ -6,9 +6,13 @@
   <header id="header">
     <div class="container">
       <%= image_tag "https://d5izmuz0mcjzz.cloudfront.net/design_course/servise-name.png" %>
+      <% if deadline_judge %>
       <button class="cta-btn" role="link" type="button">
         お申し込みはこちら
       </button>
+      <% else %>
+          <a href="https://line.me/R/ti/p/%40fyp8311b" class="l-step cta-btn">LINEに登録  </a>
+      <% end %>
     </div>
   </header>
   <!-- FV -->

--- a/app/views/static_pages/php.html.erb
+++ b/app/views/static_pages/php.html.erb
@@ -11,7 +11,11 @@
   <header>
     <div class="header-wrapper wrapper">
       <%= image_tag "https://d5izmuz0mcjzz.cloudfront.net/php/header-logo.png" %>
-      <button class="cta-btn" role="link" type="button">PHP講座を申し込む</button>
+      <% if deadline_judge %>
+        <button class="cta-btn" role="link" type="button">PHP講座を申し込む</button>
+      <% else %>
+        <a href="https://line.me/R/ti/p/%40fyp8311b" class="l-step cta-btn">LINEに登録</a>
+      <% end %>
     </div>
   </header>
 <!--


### PR DESCRIPTION
## issue 番号

Closes #366

## 実装内容


- PHP・デザイン講座の日付けによる申し込み先変更
  - 1~23日、LINEへ誘導
  - 24日以降、従来の申込先
  - helperにコーディング済み
 
 - PHP・デザイン講座の毎月締切日の自動更新
 - デザイン講座の価格表示の崩れを変更


## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）
![スクリーンショット 2021-06-25 17 43 39](https://user-images.githubusercontent.com/72480764/123401911-2f6e1200-d5e2-11eb-887a-3f79a828c0f8.png)


## 備考
特になし